### PR TITLE
Improvements to the rendering of map markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Material Icons font used for marker glyphs -->
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
     <!--<link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"

--- a/src/composables/game/useMap.ts
+++ b/src/composables/game/useMap.ts
@@ -2,31 +2,54 @@ import { Ref, onMounted, shallowRef } from "vue";
 
 export const useMap = (mapRef: Ref<HTMLElement | undefined>) => {
   const map = shallowRef<google.maps.Map>();
-  const markers = shallowRef<google.maps.Marker[]>([]);
+  const markers = shallowRef<google.maps.marker.AdvancedMarkerElement[]>([]);
   const polylines = shallowRef<google.maps.Polyline[]>([]);
 
   const removeMarkers = (): void => {
     markers.value.forEach((marker) => {
-      marker.setMap(null);
+      marker.map = null;
     });
     markers.value.splice(0);
   };
 
-  const putMarker = (position: google.maps.LatLng): void => {
-    const marker = new google.maps.Marker({
+  const putMarker = (position: google.maps.LatLng, type: "actual" | "guess" | "otherPlayer", colour: string): void => {
+    const span = document.createElement("span");
+    span.style.fontFamily = "'Material Icons'";
+    span.style.fontSize = "18px";
+    span.innerHTML = type == "actual" ? "\ue153" : (type == "guess" ? "\ue837" : "\ue853");
+    const marker = new google.maps.marker.AdvancedMarkerElement({
       position: position,
       map: map.value,
+      content: new google.maps.marker.PinElement({
+        glyph: span,
+        glyphColor: "#ffffff",
+        background: colour,
+        borderColor: colour
+      }).element
     });
     markers.value.push(marker);
   };
 
   const drawPolyline = (
     from: google.maps.LatLng,
-    to: google.maps.LatLng
+    to: google.maps.LatLng,
+    strokeColor: string
   ): void => {
     const polyline = new google.maps.Polyline({
       path: [from, to],
-      strokeColor: "hsl(0, 100%, 63%)",
+      strokeColor,
+      strokeOpacity: 0,
+      icons: [
+        {
+          icon: {
+            path: "M 0,-1 0,1",
+            strokeOpacity: 1,
+            scale: 4,
+          },
+          offset: "10px",
+          repeat: "20px"
+        }
+      ]
     });
     polyline.setMap(map.value as google.maps.Map);
     polylines.value.push(polyline);
@@ -47,6 +70,10 @@ export const useMap = (mapRef: Ref<HTMLElement | undefined>) => {
         fullscreenControl: false,
         mapTypeControl: false,
         streetViewControl: false,
+        // Unfortunately, Google requires a map ID in order to use Advanced Markers.
+        // To save people hosting the game from having to create a map ID, we use
+        // the demo ID (even though Google recommends using it only for testing).
+        mapId: "DEMO_MAP_ID"
       });
     }
   });

--- a/src/stores/inGame.ts
+++ b/src/stores/inGame.ts
@@ -5,7 +5,7 @@ import { computed, ref } from "vue";
 interface InGameState {
   randomLatLng: google.maps.LatLng | null;
   selectedLatLng: google.maps.LatLng | null;
-  selectedLatLngArr: Array<google.maps.LatLng>;
+  selectedLatLngMap: Map<string, google.maps.LatLng>;
   gameHistory: Array<GameHistory>;
   distanceByPlayerArr: Array<DistanceByPlayer>;
   multiplayerGameSummary: Array<Summary>;
@@ -29,7 +29,7 @@ export const useInGameStore = defineStore("inGame", () => {
   const inGameState = ref<InGameState>({
     randomLatLng: null,
     selectedLatLng: null,
-    selectedLatLngArr: [],
+    selectedLatLngMap: new Map(),
     gameHistory: [],
     distanceByPlayerArr: [],
     multiplayerGameSummary: [],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,3 +28,17 @@ export const getIconUrl = (icon: string) => {
     import.meta.url
   ).href;
 };
+
+// @see https://stackoverflow.com/a/16348977/14269655
+export const stringToColour = (str: string) => {
+  let hash = 0;
+  str.split("").forEach(char => {
+    hash = char.charCodeAt(0) + ((hash << 5) - hash);
+  });
+  let colour = "#";
+  for (let i = 0; i < 3; i++) {
+    const value = (hash >> (i * 8)) & 0xff;
+    colour += value.toString(16).padStart(2, "0");
+  }
+  return colour;
+}

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -67,7 +67,8 @@
           :selected-mode="gameSettingsState.selectedMode"
           :random-lat-lng="inGameState.randomLatLng"
           :selected-lat-lng="inGameState.selectedLatLng"
-          :selected-lat-lng-arr="inGameState.selectedLatLngArr"
+          :selected-lat-lng-map="inGameState.selectedLatLngMap"
+          :own-colour="gameSettingsState.playerId ? stringToColour(gameSettingsState.playerId) : 'hsl(0, 100%, 63%)'"
           :game-history="inGameState.gameHistory"
           @update-selected-lat-lng="(val: google.maps.LatLng) => inGameState.selectedLatLng = val"
         />
@@ -146,6 +147,7 @@ import OverlayComponent from "@/components/game/OverlayComponent.vue";
 import IconButtonComponent from "@/components/shared/IconButtonComponent.vue";
 import { database } from "@/firebase";
 import { DEVICE_TYPES } from "@/constants";
+import { stringToColour } from "@/utils";
 import { storeToRefs } from "pinia";
 import { useGameSettingsStore } from "@/stores/gameSettings";
 import { useInGameStore } from "@/stores/inGame";
@@ -336,7 +338,7 @@ const listenGuesses = () => {
           const lat = childSnapshot.child("lat").val();
           const lng = childSnapshot.child("lng").val();
           const latlng = new google.maps.LatLng(lat, lng);
-          inGameState.value.selectedLatLngArr.push(latlng);
+          inGameState.value.selectedLatLngMap.set(childSnapshot.key ?? "", latlng);
         });
 
         await retrieveDistance();
@@ -440,7 +442,7 @@ const onClickNextRoundButton = async (): Promise<void> => {
     inGameState.value.isMapVisible = false;
     inGameState.value.randomLatLng = null;
     inGameState.value.selectedLatLng = null;
-    inGameState.value.selectedLatLngArr = [];
+    inGameState.value.selectedLatLngMap = new Map();
     inGameState.value.distanceByPlayerArr = [];
 
     mapRef.value?.removeMarkers();


### PR DESCRIPTION
This PR implements using different glyphs and colours to better distinguish map markers. A flag is used to represent the actual location of the Street View image, a circle for your guess, and a person image for the guess of another player. A colour is generated for each player based on their player ID.

This PR also migrates to the new Advanced Markers API from the deprecated `google.maps.Marker`.

Singleplayer

![Screenshot from 2024-06-23 20-33-25](https://github.com/spider-hand/GeoguessMaster/assets/63245705/aa772467-bedf-4dd8-89d2-9814012610df)

Multiplayer

![Screenshot from 2024-06-23 20-36-49](https://github.com/spider-hand/GeoguessMaster/assets/63245705/7e4567c1-3cdc-41b5-837e-19116e454673)
